### PR TITLE
Hw 02

### DIFF
--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -56,11 +56,12 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), 1.seconds.toJavaDuration())
     private val requestQueue: BlockingQueue<PaymentRequest> = LinkedBlockingQueue()
 
-    private val executorThreadNumber = 1
+    private val executorThreadNumber = 16
     private val executorService = Executors.newFixedThreadPool(executorThreadNumber)
     private val coroutineScope = CoroutineScope(executorService.asCoroutineDispatcher() + SupervisorJob())
 
-    private val maxConcurrentRequests: Int = (rateLimitPerSec * requestAverageProcessingTime.toKotlinDuration().toDouble(DurationUnit.SECONDS)).toInt().coerceAtLeast(1)
+    //private val maxConcurrentRequests: Int = (rateLimitPerSec * requestAverageProcessingTime.toKotlinDuration().toDouble(DurationUnit.SECONDS)).toInt().coerceAtLeast(1)
+    private val maxConcurrentRequests: Int = parallelRequests
     private val requestSemaphore = Semaphore(permits = maxConcurrentRequests)
 
     init {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -3,19 +3,25 @@ package ru.quipy.payments.logic
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.slf4j.LoggerFactory
 import ru.quipy.common.utils.SlidingWindowRateLimiter
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.net.SocketTimeoutException
-import java.time.Duration
 import java.util.*
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import kotlin.time.toJavaDuration
+import kotlin.time.toKotlinDuration
 
 data class PaymentRequest(
     val paymentId: UUID,
@@ -36,7 +42,7 @@ class PaymentExternalSystemAdapterImpl(
     companion object {
         val logger = LoggerFactory.getLogger(PaymentExternalSystemAdapter::class.java)
 
-        val emptyBody = RequestBody.create(null, ByteArray(0))
+        val emptyBody = ByteArray(0).toRequestBody(null)
         val mapper = ObjectMapper().registerKotlinModule()
     }
 
@@ -47,16 +53,18 @@ class PaymentExternalSystemAdapterImpl(
     private val parallelRequests = properties.parallelRequests
 
     private val client = OkHttpClient.Builder().build()
-    
-    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), Duration.ofSeconds(1))
-    
+    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), 1.seconds.toJavaDuration())
     private val requestQueue: BlockingQueue<PaymentRequest> = LinkedBlockingQueue()
-    
-    private val executorService = Executors.newFixedThreadPool(16)
+
+    private val executorThreadNumber = 1
+    private val executorService = Executors.newFixedThreadPool(executorThreadNumber)
     private val coroutineScope = CoroutineScope(executorService.asCoroutineDispatcher() + SupervisorJob())
-    
+
+    private val maxConcurrentRequests: Int = (rateLimitPerSec * requestAverageProcessingTime.toKotlinDuration().toDouble(DurationUnit.SECONDS)).toInt().coerceAtLeast(1)
+    private val requestSemaphore = Semaphore(permits = maxConcurrentRequests)
+
     init {
-        repeat(16) {
+        repeat(executorThreadNumber) {
             coroutineScope.launch {
                 processRequestQueue()
             }
@@ -68,33 +76,41 @@ class PaymentExternalSystemAdapterImpl(
 
         val request = PaymentRequest(paymentId, amount, paymentStartedAt, deadline, transactionId)
         requestQueue.offer(request)
-        logger.warn("[$accountName] Submitted payment request into queue $paymentId, time spent ${now() - paymentStartedAt}")
+        logger.warn("[$accountName] Submitted payment request into queue $paymentId, time spent ${now() - paymentStartedAt} ms")
     }
-    
+
     private suspend fun processRequestQueue() {
         while (true) {
             try {
                 val request = requestQueue.take()
-                withContext(Dispatchers.IO) {
-                    rateLimiter.tickBlocking()
+
+                requestSemaphore.withPermit {
+                    withContext(Dispatchers.IO) {
+                        rateLimiter.tickBlocking()
+                    }
+                    processPaymentRequest(request)
                 }
-                processPaymentRequest(request)
             } catch (e: Exception) {
                 logger.error("[$accountName] Error processing request queue", e)
             }
         }
     }
-    
+
     private suspend fun processPaymentRequest(request: PaymentRequest) {
         // Вне зависимости от исхода оплаты важно отметить что она была отправлена.
         // Это требуется сделать ВО ВСЕХ СЛУЧАЯХ, поскольку эта информация используется сервисом тестирования.
         withContext(Dispatchers.IO) {
             paymentESService.update(request.paymentId) {
-                it.logSubmission(success = true, request.transactionId, now(), Duration.ofMillis(now() - request.paymentStartedAt))
+                it.logSubmission(
+                    success = true,
+                    request.transactionId,
+                    now(),
+                    (now() - request.paymentStartedAt).milliseconds.toJavaDuration()
+                )
             }
         }
 
-        logger.info("[$accountName] Submit: ${request.paymentId} , txId: ${request.transactionId}, time spent ${now() - request.paymentStartedAt}")
+        logger.info("[$accountName] Submit: ${request.paymentId} , txId: ${request.transactionId}, time spent ${now() - request.paymentStartedAt} ms")
 
         try {
             val httpRequest = Request.Builder().run {
@@ -105,16 +121,21 @@ class PaymentExternalSystemAdapterImpl(
             val response = withContext(Dispatchers.IO) {
                 client.newCall(httpRequest).execute()
             }
-            
+
             response.use { resp ->
                 val body = try {
                     mapper.readValue(resp.body?.string(), ExternalSysResponse::class.java)
                 } catch (e: Exception) {
                     logger.error("[$accountName] [ERROR] Payment processed for txId: ${request.transactionId}, payment: ${request.paymentId}, result code: ${resp.code}, reason: ${resp.body?.string()}")
-                    ExternalSysResponse(request.transactionId.toString(), request.paymentId.toString(), false, e.message)
+                    ExternalSysResponse(
+                        request.transactionId.toString(),
+                        request.paymentId.toString(),
+                        false,
+                        e.message
+                    )
                 }
 
-                logger.warn("[$accountName] Payment processed for txId: ${request.transactionId}, payment: ${request.paymentId}, succeeded: ${body.result}, message: ${body.message}, time spent ${now() - request.paymentStartedAt}")
+                logger.warn("[$accountName] Payment processed for txId: ${request.transactionId}, payment: ${request.paymentId}, succeeded: ${body.result}, message: ${body.message}, time spent ${now() - request.paymentStartedAt} ms")
 
                 // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
                 // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)
@@ -127,7 +148,10 @@ class PaymentExternalSystemAdapterImpl(
         } catch (e: Exception) {
             when (e) {
                 is SocketTimeoutException -> {
-                    logger.error("[$accountName] Payment timeout for txId: ${request.transactionId}, payment: ${request.paymentId}, time spent ${now() - request.paymentStartedAt}", e)
+                    logger.error(
+                        "[$accountName] Payment timeout for txId: ${request.transactionId}, payment: ${request.paymentId}, time spent ${now() - request.paymentStartedAt} ms",
+                        e
+                    )
                     withContext(Dispatchers.IO) {
                         paymentESService.update(request.paymentId) {
                             it.logProcessing(false, now(), request.transactionId, reason = "Request timeout.")
@@ -136,7 +160,10 @@ class PaymentExternalSystemAdapterImpl(
                 }
 
                 else -> {
-                    logger.error("[$accountName] Payment failed for txId: ${request.transactionId}, payment: ${request.paymentId}, time spent ${now() - request.paymentStartedAt}", e)
+                    logger.error(
+                        "[$accountName] Payment failed for txId: ${request.transactionId}, payment: ${request.paymentId}, time spent ${now() - request.paymentStartedAt} ms",
+                        e
+                    )
                     withContext(Dispatchers.IO) {
                         paymentESService.update(request.paymentId) {
                             it.logProcessing(false, now(), request.transactionId, reason = e.message)

--- a/test-local-run.http
+++ b/test-local-run.http
@@ -12,4 +12,4 @@ Content-Type: application/json
 
 ### Stop running test to save time and resources
 # @timeout 120
-POST http://localhost:4321/test/stop/"{{serviceName}}"
+POST http://localhost:1234/test/stop/{{serviceName}}

--- a/test-on-prem-run.http
+++ b/test-on-prem-run.http
@@ -16,4 +16,4 @@ Content-Type: application/json
 
 ### Stop running test to save credits
 # @timeout 120
-POST http://77.234.215.138:31234/test/stop/"{{serviceName}}"
+POST http://77.234.215.138:31234/test/stop/{{serviceName}}


### PR DESCRIPTION
## Кейс
Аккаунт:  "acc-5"
```
parallelRequests=5
rateLimitPerSec=3
price=30
averageProcessingTime=PT4.9S
enabled=true
```

Тест:
```http
{
  "ratePerSecond": 2,
  "testCount": 100,
  "processingTimeMillis": 60000
}
```

## В чем была проблема
При попытке запустить тесты получаем ошибки о том, что превышено количество паралелльных запросов во внешний сервис. Наши клиенты не получают ответ и теряются по таймауту (превышено их время ожидания).

## Гипотеза почему это происходило
Задача заключается в долгой обработке и ограниченном количестве паралелльных запросов во внешнем сервисе.
Текущая реализация сервиса отправляла запросы без данной особенности в аккаунт не учитывая ограничение на параллелизм.

## Решение
Внедрили семафору с permits = паралеллизм во внешнем сервисе. Также оставили rate limiter.
Теперь когда приходит очередной запрос на оплату, то поток ожидает освобождения семафоры. Как только она освободилась, то первый успевший поток ее занимает. После обработки, даже при падении, семафора освобождается и продолжается выполнение других потоков с учетом ограничения rate limiter.

## Почему эти изменения исправляют проблему
Это решени позволяет регулировать паралеллизм запросов во внешний сервис на строне нашего сервиса с помощью семафор. И контролировать возможный максимальный rps во внешний сервис.

## Результаты
http://77.234.215.138:33000/d/KVr-Vmpnz/services-statistic?orgId=1&from=2025-09-26T10:10:00.000Z&to=2025-09-26T10:15:59.000Z&timezone=browser&var-service=pelmeni&refresh=5s
<img width="2436" height="1434" alt="Screenshot From 2025-09-26 13-16-54" src="https://github.com/user-attachments/assets/ca6e192a-25b6-4c4f-8629-04dedf52674f" />
<img width="2414" height="1490" alt="Screenshot From 2025-09-26 13-17-12" src="https://github.com/user-attachments/assets/4f34868c-c7ac-4110-a020-612577b496e4" />
