### PR TITLE
Hw 04

### DIFF
--- a/src/main/kotlin/ru/quipy/apigateway/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/ru/quipy/apigateway/GlobalExceptionHandler.kt
@@ -1,0 +1,25 @@
+package ru.quipy.apigateway
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+import ru.quipy.payments.logic.TooManyRequestsException
+
+@ControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(TooManyRequestsException::class)
+    fun handleTooManyRequests(e: TooManyRequestsException): ResponseEntity<String> {
+        val headers = HttpHeaders()
+
+        e.retryAfterTimestamp?.let { timestamp ->
+            headers.set("Retry-After", timestamp.toString())
+        }
+
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+            .headers(headers)
+            .body("Too many requests: ${e.message}")
+    }
+}

--- a/src/main/kotlin/ru/quipy/config/MetricsConfig.kt
+++ b/src/main/kotlin/ru/quipy/config/MetricsConfig.kt
@@ -9,6 +9,7 @@ class MetricsConfig(
     var incomingRequests: MetricProperties = MetricProperties(),
     var outgoingResponses: MetricProperties = MetricProperties(),
     var completedTasks: MetricProperties = MetricProperties(),
+    var queueSize: MetricProperties = MetricProperties(),
 ) {
     data class MetricProperties(
         var name: String = "defaultName",

--- a/src/main/kotlin/ru/quipy/metrics/MetricsService.kt
+++ b/src/main/kotlin/ru/quipy/metrics/MetricsService.kt
@@ -1,6 +1,7 @@
 package ru.quipy.metrics
 
 import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Tag
 import org.springframework.stereotype.Service
@@ -22,6 +23,14 @@ class MetricsService(
 
     fun incrementCompletedTask(method: String) {
         registerCounter(metricsConfig.completedTasks, listOf(method)).increment()
+    }
+
+    fun registerQueueSizeGauge(accountName: String, gaugeObject: Any, valueFunction: () -> Double) {
+        val tags = listOf(Tag.of("account", accountName))
+        Gauge.builder(metricsConfig.queueSize.name, gaugeObject) { valueFunction() }
+            .description(metricsConfig.queueSize.description)
+            .tags(tags)
+            .register(Metrics.globalRegistry)
     }
 
     private fun registerCounter(config: MetricsConfig.MetricProperties, tags: List<String>): Counter {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -4,14 +4,9 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import ru.quipy.common.utils.CallerBlockingRejectedExecutionHandler
-import ru.quipy.common.utils.NamedThreadFactory
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.util.*
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
 
 @Service
 class OrderPayer {
@@ -21,35 +16,18 @@ class OrderPayer {
     }
 
     @Autowired
-    private lateinit var paymentESService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>
-
-    @Autowired
     private lateinit var paymentService: PaymentService
-
-    private val paymentExecutor = ThreadPoolExecutor(
-        16,
-        16,
-        0L,
-        TimeUnit.MILLISECONDS,
-        LinkedBlockingQueue(8_000),
-        NamedThreadFactory("payment-submission-executor"),
-        CallerBlockingRejectedExecutionHandler()
-    )
 
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
-        paymentExecutor.submit {
-            val createdEvent = paymentESService.create {
-                it.create(
-                    paymentId,
-                    orderId,
-                    amount
-                )
-            }
-            logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
 
-            paymentService.submitPaymentRequest(paymentId, amount, createdAt, deadline)
+        try {
+            paymentService.submitPaymentRequest(orderId, paymentId, amount, createdAt, deadline)
+        } catch (e: TooManyRequestsException) {
+            logger.warn("Too many requests for payment $paymentId, rejecting with 429")
+            throw e
         }
+        
         return createdAt
     }
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -14,6 +14,7 @@ import ru.quipy.config.ThreadPoolsConfig
 import ru.quipy.core.EventSourcingService
 import ru.quipy.metrics.MetricsService
 import ru.quipy.payments.api.PaymentAggregate
+import ru.quipy.payments.logic.OrderPayer.Companion
 import java.net.SocketTimeoutException
 import java.util.*
 import java.util.concurrent.BlockingQueue
@@ -68,6 +69,8 @@ class PaymentExternalSystemAdapterImpl(
     private val requestSemaphore = Semaphore(permits = maxConcurrentRequests)
 
     init {
+        metricsService.registerQueueSizeGauge(accountName, this) { requestQueue.size.toDouble() }
+        
         repeat(executorThreadNumber) {
             coroutineScope.launch {
                 processRequestQueue()
@@ -75,11 +78,32 @@ class PaymentExternalSystemAdapterImpl(
         }
     }
 
-    override fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+    override fun performPaymentAsync(paymentId: UUID, orderId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
         val transactionId = UUID.randomUUID()
+
+        val processingTimeSeconds = requestAverageProcessingTime.toMillis() / 1000.0
+        val maxRpsFromConcurrency = maxConcurrentRequests / processingTimeSeconds
+        val effectiveRps = minOf(maxRpsFromConcurrency, rateLimitPerSec.toDouble())
+
+        val timeRemaining = deadline - now()
+        val timeNeededToProcessQueue = requestQueue.size / effectiveRps * 1000 * 1.1 // in milliseconds
+
+        if (timeRemaining <= 0 || timeNeededToProcessQueue > timeRemaining) {
+            val retryAfterTimestamp = now() + (requestQueue.size / effectiveRps * 1000 * 1.1).toLong()
+            throw TooManyRequestsException("Too many requests", retryAfterTimestamp)
+        }
+
+        val createdEvent = paymentESService.create {
+            it.create(
+                paymentId,
+                orderId,
+                amount
+            )
+        }
 
         val request = PaymentRequest(paymentId, amount, paymentStartedAt, deadline, transactionId)
         requestQueue.offer(request)
+        OrderPayer.logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
         logger.warn("[$accountName] Submitted payment request into queue $paymentId, time spent ${now() - paymentStartedAt} ms")
     }
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentService.kt
@@ -6,8 +6,9 @@ import java.util.*
 interface PaymentService {
     /**
      * Submit payment request to some external service.
+     * @throws TooManyRequestsException if back pressure is applied
      */
-    fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
+    fun submitPaymentRequest(orderId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
 }
 
 /**
@@ -17,7 +18,7 @@ interface PaymentService {
 
  */
 interface PaymentExternalSystemAdapter {
-    fun performPaymentAsync(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
+    fun performPaymentAsync(paymentId: UUID,  orderId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long)
 
     fun name(): String
 

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
@@ -3,7 +3,6 @@ package ru.quipy.payments.logic
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import ru.quipy.common.utils.NamedThreadFactory
 import ru.quipy.core.EventSourcingService
 import ru.quipy.payments.api.PaymentAggregate
 import java.time.Duration
@@ -21,9 +20,23 @@ class PaymentSystemImpl(
         val logger = LoggerFactory.getLogger(PaymentSystemImpl::class.java)
     }
 
-    override fun submitPaymentRequest(paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+    override fun submitPaymentRequest(orderId: UUID, paymentId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+        var bestRetryAfterTimestamp: Long? = null
+        
         for (account in paymentAccounts) {
-            account.performPaymentAsync(paymentId, amount, paymentStartedAt, deadline)
+            try {
+                account.performPaymentAsync(paymentId, orderId, amount, paymentStartedAt, deadline)
+                return
+            } catch (e: TooManyRequestsException) {
+                logger.warn("Account ${account.name()} rejected payment $paymentId due to back pressure")
+                // Keep the earliest retry timestamp
+                e.retryAfterTimestamp?.let { timestamp ->
+                    if (bestRetryAfterTimestamp == null || timestamp < bestRetryAfterTimestamp!!) {
+                        bestRetryAfterTimestamp = timestamp
+                    }
+                }
+            }
         }
+        throw TooManyRequestsException("All payment accounts are under back pressure", bestRetryAfterTimestamp)
     }
 }

--- a/src/main/kotlin/ru/quipy/payments/logic/TooManyRequestsException.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/TooManyRequestsException.kt
@@ -1,0 +1,10 @@
+package ru.quipy.payments.logic
+
+/**
+ * Exception thrown when too many requests are received and back pressure is applied.
+ * This should result in HTTP 429 Too Many Requests response.
+ */
+class TooManyRequestsException(
+    message: String,
+    val retryAfterTimestamp: Long? = null
+) : RuntimeException(message)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,6 +64,11 @@ metrics:
     description: "completed tasks"
     tags:
       - method
+  queue-size:
+    name: payment_queue_size
+    description: "payment queue size"
+    tags:
+      - account
 
 thread-pools:
   payment-external-service-thread-pool-config:


### PR DESCRIPTION
## Кейс
Аккаунт: "acc-23"
```
accountName=acc-23
parallelRequests=64
rateLimitPerSec=11
price=30
averageProcessingTime=PT1S
```
Тест:
```
{
  "ratePerSecond": 16,
  "testCount": 1600,
  "processingTimeMillis": 30000
}

```
## В чем была проблема
При попытке запустить тест изначально все нормально, но постепенно увеличивается время выполнения платежа.  В какой-то момент время выполнения превышает время ожидания и оплата не проходит
## Гипотеза почему это происходило
На вход подается 16 rps, при этом сервис способен обрабатывать 11rps
## Решение
Решения нет, т.к. пропускная способность зависит от параметров аккаунта. 

Складываем запросы в очередь, пока видим что очередь возможно разобрать с нашим rps до дедлайна. 

Если приходит очередной запрос и по текущему размеру очереди видно, что запрос не будет обработан до дедлайна, возвращаем 429.

Также был построен график размера очереди. По нему видно, что размер очереди не превышает 330, то есть rps (11) * время ожидания (30c)

<img width="2515" height="1120" alt="image" src="https://github.com/user-attachments/assets/f858ba97-c6d2-4739-bb9d-6a0b395f55af" />


