### PR TITLE
Hw 05

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -7,10 +7,6 @@ scrape_configs:
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: ['bombardier:1234']
-  - job_name: 'bombardier-host-job'
-    metrics_path: '/actuator/prometheus'
-    static_configs:
-      - targets: ['host.docker.internal:1234']
   - job_name: 'online-store-job'
     metrics_path: '/actuator/prometheus'
     static_configs:

--- a/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
+++ b/src/main/kotlin/ru/quipy/common/utils/SlidingWindowRateLimiter.kt
@@ -39,6 +39,14 @@ class SlidingWindowRateLimiter(
         }
     }
 
+    /**
+     * Возвращает токен обратно в рейт лимитер.
+     * Уменьшает счетчик токенов, чтобы освободить место для других запросов.
+     */
+    fun returnToken() {
+        sum.decrementAndGet()
+    }
+
     data class Measure(
         val value: Long,
         val timestamp: Long

--- a/src/main/kotlin/ru/quipy/config/MetricsConfig.kt
+++ b/src/main/kotlin/ru/quipy/config/MetricsConfig.kt
@@ -10,6 +10,7 @@ class MetricsConfig(
     var outgoingResponses: MetricProperties = MetricProperties(),
     var completedTasks: MetricProperties = MetricProperties(),
     var queueSize: MetricProperties = MetricProperties(),
+    var externalSystemResponseTime: MetricProperties = MetricProperties(),
 ) {
     data class MetricProperties(
         var name: String = "defaultName",

--- a/src/main/kotlin/ru/quipy/metrics/MetricsService.kt
+++ b/src/main/kotlin/ru/quipy/metrics/MetricsService.kt
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Tag
+import io.micrometer.core.instrument.Timer
 import org.springframework.stereotype.Service
 import ru.quipy.config.MetricsConfig
 
@@ -31,6 +32,17 @@ class MetricsService(
             .description(metricsConfig.queueSize.description)
             .tags(tags)
             .register(Metrics.globalRegistry)
+    }
+
+    fun recordExternalSystemResponseTime(accountName: String, durationMillis: Long) {
+        val tags = listOf(Tag.of("account", accountName))
+        val timer = Timer
+            .builder(metricsConfig.externalSystemResponseTime.name)
+            .description(metricsConfig.externalSystemResponseTime.description)
+            .tags(tags)
+            .publishPercentiles(0.5, 0.75, 0.9, 0.95, 0.99)
+            .register(Metrics.globalRegistry)
+        timer.record(durationMillis, java.util.concurrent.TimeUnit.MILLISECONDS)
     }
 
     private fun registerCounter(config: MetricsConfig.MetricProperties, tags: List<String>): Counter {

--- a/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/OrderPayer.kt
@@ -21,12 +21,7 @@ class OrderPayer {
     fun processPayment(orderId: UUID, amount: Int, paymentId: UUID, deadline: Long): Long {
         val createdAt = System.currentTimeMillis()
 
-        try {
-            paymentService.submitPaymentRequest(orderId, paymentId, amount, createdAt, deadline)
-        } catch (e: TooManyRequestsException) {
-            logger.warn("Too many requests for payment $paymentId, rejecting with 429")
-            throw e
-        }
+        paymentService.submitPaymentRequest(orderId, paymentId, amount, createdAt, deadline)
         
         return createdAt
     }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -110,12 +110,11 @@ class PaymentExternalSystemAdapterImpl(
             // ceil is needed because we need 2s to process 12 requests with 11rps (11 requests in first sec + 1 request in second sec)
             val timeNeededToProcessQueueWithNewRequest = (requestQueue.size + effectiveRps) / effectiveRps * 1000 + requestAverageProcessingTime.toMillis() // in milliseconds
 
-            if (timeRemaining <= 0 || timeNeededToProcessQueueWithNewRequest > timeRemaining) {
-                val retryAfterTimestamp = currentTime + timeNeededToProcessQueueWithNewRequest
-                lastRetryAfterTimestamp = retryAfterTimestamp
+            if (timeRemaining <= 0 || timeNeededToProcessQueueWithNewRequest + 300 > timeRemaining) {
+                lastRetryAfterTimestamp = currentTime + timeNeededToProcessQueueWithNewRequest
 
-                logger.warn("[$accountName] TooManyRequestsException for paymemt $paymentId, retry-after time $retryAfterTimestamp ms, queue size ${requestQueue.size}, time needed $timeNeededToProcessQueueWithNewRequest")
-                throw TooManyRequestsException("Too many requests", retryAfterTimestamp)
+                logger.warn("[$accountName] TooManyRequestsException for paymemt $paymentId, retry-after time $lastRetryAfterTimestamp ms, queue size ${requestQueue.size}, time needed $timeNeededToProcessQueueWithNewRequest")
+                throw TooManyRequestsException("Too many requests", lastRetryAfterTimestamp)
             }
 
             val createdEvent = paymentESService.create {
@@ -136,6 +135,10 @@ class PaymentExternalSystemAdapterImpl(
         while (true) {
             try {
                 val request = requestQueue.take()
+
+                if (now() + requestAverageProcessingTime.toMillis() > request.deadline) {
+                    continue
+                }
 
                 requestSemaphore.withPermit {
                     withContext(Dispatchers.IO) {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -14,7 +14,6 @@ import ru.quipy.config.ThreadPoolsConfig
 import ru.quipy.core.EventSourcingService
 import ru.quipy.metrics.MetricsService
 import ru.quipy.payments.api.PaymentAggregate
-import ru.quipy.payments.logic.OrderPayer.Companion
 import java.net.SocketTimeoutException
 import java.util.*
 import java.util.concurrent.BlockingQueue
@@ -70,7 +69,7 @@ class PaymentExternalSystemAdapterImpl(
 
     init {
         metricsService.registerQueueSizeGauge(accountName, this) { requestQueue.size.toDouble() }
-        
+
         repeat(executorThreadNumber) {
             coroutineScope.launch {
                 processRequestQueue()
@@ -78,18 +77,25 @@ class PaymentExternalSystemAdapterImpl(
         }
     }
 
-    override fun performPaymentAsync(paymentId: UUID, orderId: UUID, amount: Int, paymentStartedAt: Long, deadline: Long) {
+    override fun performPaymentAsync(
+        paymentId: UUID,
+        orderId: UUID,
+        amount: Int,
+        paymentStartedAt: Long,
+        deadline: Long
+    ) {
         val transactionId = UUID.randomUUID()
 
-        val processingTimeSeconds = requestAverageProcessingTime.toMillis() / 1000.0
-        val maxRpsFromConcurrency = maxConcurrentRequests / processingTimeSeconds
-        val effectiveRps = minOf(maxRpsFromConcurrency, rateLimitPerSec.toDouble())
+        val maxRpsFromConcurrency = maxConcurrentRequests / requestAverageProcessingTime.seconds
+        val effectiveRps = minOf(maxRpsFromConcurrency, rateLimitPerSec.toLong())
 
         val timeRemaining = deadline - now()
         val timeNeededToProcessQueue = requestQueue.size / effectiveRps * 1000 * 1.1 // in milliseconds
 
         if (timeRemaining <= 0 || timeNeededToProcessQueue > timeRemaining) {
             val retryAfterTimestamp = now() + (requestQueue.size / effectiveRps * 1000 * 1.1).toLong()
+
+            logger.warn("[$accountName] TooManyRequestsException for paymemt $paymentId, retry-after time $retryAfterTimestamp ms")
             throw TooManyRequestsException("Too many requests", retryAfterTimestamp)
         }
 
@@ -104,7 +110,7 @@ class PaymentExternalSystemAdapterImpl(
         val request = PaymentRequest(paymentId, amount, paymentStartedAt, deadline, transactionId)
         requestQueue.offer(request)
         OrderPayer.logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
-        logger.warn("[$accountName] Submitted payment request into queue $paymentId, time spent ${now() - paymentStartedAt} ms")
+        logger.info("[$accountName] Submitted payment request into queue $paymentId, time spent ${now() - paymentStartedAt} ms")
     }
 
     private suspend fun processRequestQueue() {
@@ -165,7 +171,7 @@ class PaymentExternalSystemAdapterImpl(
                     )
                 }
 
-                logger.warn("[$accountName] Payment processed for txId: ${request.transactionId}, payment: ${request.paymentId}, succeeded: ${body.result}, message: ${body.message}, time spent ${now() - request.paymentStartedAt} ms")
+                logger.info("[$accountName] Payment processed for txId: ${request.transactionId}, payment: ${request.paymentId}, succeeded: ${body.result}, message: ${body.message}, time spent ${now() - request.paymentStartedAt} ms")
 
                 // Здесь мы обновляем состояние оплаты в зависимости от результата в базе данных оплат.
                 // Это требуется сделать ВО ВСЕХ ИСХОДАХ (успешная оплата / неуспешная / ошибочная ситуация)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -110,7 +110,7 @@ class PaymentExternalSystemAdapterImpl(
             // ceil is needed because we need 2s to process 12 requests with 11rps (11 requests in first sec + 1 request in second sec)
             val timeNeededToProcessQueueWithNewRequest = (requestQueue.size + effectiveRps) / effectiveRps * 1000 + requestAverageProcessingTime.toMillis() // in milliseconds
 
-            if (timeRemaining <= 0 || timeNeededToProcessQueueWithNewRequest + 300 > timeRemaining) {
+            if (timeRemaining <= 0 || timeNeededToProcessQueueWithNewRequest + 100 > timeRemaining) {
                 lastRetryAfterTimestamp = currentTime + timeNeededToProcessQueueWithNewRequest
 
                 logger.warn("[$accountName] TooManyRequestsException for paymemt $paymentId, retry-after time $lastRetryAfterTimestamp ms, queue size ${requestQueue.size}, time needed $timeNeededToProcessQueueWithNewRequest")
@@ -136,7 +136,7 @@ class PaymentExternalSystemAdapterImpl(
             try {
                 val request = requestQueue.take()
 
-                if (now() + requestAverageProcessingTime.toMillis() > request.deadline) {
+                if (now() + requestAverageProcessingTime.toMillis() + 100 > request.deadline) {
                     continue
                 }
 
@@ -144,14 +144,15 @@ class PaymentExternalSystemAdapterImpl(
                     withContext(Dispatchers.IO) {
                         rateLimiter.tickBlocking()
                     }
-                    
-                    val currentTime = now()
-                    if (currentTime + requestAverageProcessingTime.toMillis() > request.deadline) {
-                        rateLimiter.returnToken()
-                        logger.warn("[$accountName] Request ${request.paymentId} missed deadline, returning token to rate limiter")
-                    } else {
-                        processPaymentRequest(request)
-                    }
+                    processPaymentRequest(request)
+                    // TODO: nice idea but token returns into new window and rate limit is breached for good requests
+                    // val currentTime = now()
+                    // if (currentTime + requestAverageProcessingTime.toMillis() > request.deadline) {
+                    //     rateLimiter.returnToken()
+                    //     logger.warn("[$accountName] Request ${request.paymentId} missed deadline, returning token to rate limiter")
+                    // } else {
+                    //     processPaymentRequest(request)
+                    // }
                 }
 
                 metricsService.incrementCompletedTask(TASK_NAME)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -90,10 +90,10 @@ class PaymentExternalSystemAdapterImpl(
         val effectiveRps = minOf(maxRpsFromConcurrency, rateLimitPerSec.toLong())
 
         val timeRemaining = deadline - now()
-        val timeNeededToProcessQueue = requestQueue.size / effectiveRps * 1000 * 1.1 // in milliseconds
+        val timeNeededToProcessQueue = ((requestQueue.size.toDouble() / effectiveRps * 1000 + requestAverageProcessingTime.toMillis()) * 1.1).toLong() // in milliseconds
 
         if (timeRemaining <= 0 || timeNeededToProcessQueue > timeRemaining) {
-            val retryAfterTimestamp = now() + (requestQueue.size / effectiveRps * 1000 * 1.1).toLong()
+            val retryAfterTimestamp = now() + timeNeededToProcessQueue
 
             logger.warn("[$accountName] TooManyRequestsException for paymemt $paymentId, retry-after time $retryAfterTimestamp ms")
             throw TooManyRequestsException("Too many requests", retryAfterTimestamp)

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -144,7 +144,14 @@ class PaymentExternalSystemAdapterImpl(
                     withContext(Dispatchers.IO) {
                         rateLimiter.tickBlocking()
                     }
-                    processPaymentRequest(request)
+                    
+                    val currentTime = now()
+                    if (currentTime + requestAverageProcessingTime.toMillis() > request.deadline) {
+                        rateLimiter.returnToken()
+                        logger.warn("[$accountName] Request ${request.paymentId} missed deadline, returning token to rate limiter")
+                    } else {
+                        processPaymentRequest(request)
+                    }
                 }
 
                 metricsService.incrementCompletedTask(TASK_NAME)
@@ -170,15 +177,18 @@ class PaymentExternalSystemAdapterImpl(
 
         logger.info("[$accountName] Submit: ${request.paymentId} , txId: ${request.transactionId}, time spent ${now() - request.paymentStartedAt} ms")
 
-        try {
-            val httpRequest = Request.Builder().run {
-                url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=${request.transactionId}&paymentId=${request.paymentId}&amount=${request.amount}")
-                post(emptyBody)
-            }.build()
+        val httpRequest = Request.Builder().run {
+            url("http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=${request.transactionId}&paymentId=${request.paymentId}&amount=${request.amount}")
+            post(emptyBody)
+        }.build()
 
+        val requestStartTime = now()
+        try {
             val response = withContext(Dispatchers.IO) {
                 client.newCall(httpRequest).execute()
             }
+            val responseTime = now() - requestStartTime
+            metricsService.recordExternalSystemResponseTime(accountName, responseTime)
 
             response.use { resp ->
                 val body = try {
@@ -204,6 +214,9 @@ class PaymentExternalSystemAdapterImpl(
                 }
             }
         } catch (e: Exception) {
+            val responseTime = now() - requestStartTime
+            metricsService.recordExternalSystemResponseTime(accountName, responseTime)
+            
             when (e) {
                 is SocketTimeoutException -> {
                     logger.error(

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -95,7 +95,7 @@ class PaymentExternalSystemAdapterImpl(
         if (timeRemaining <= 0 || timeNeededToProcessQueue > timeRemaining) {
             val retryAfterTimestamp = now() + timeNeededToProcessQueue
 
-            logger.warn("[$accountName] TooManyRequestsException for paymemt $paymentId, retry-after time $retryAfterTimestamp ms")
+            logger.warn("[$accountName] TooManyRequestsException for paymemt $paymentId, retry-after time $retryAfterTimestamp ms, queue size ${requestQueue.size}, time needed $timeNeededToProcessQueue")
             throw TooManyRequestsException("Too many requests", retryAfterTimestamp)
         }
 
@@ -109,8 +109,7 @@ class PaymentExternalSystemAdapterImpl(
 
         val request = PaymentRequest(paymentId, amount, paymentStartedAt, deadline, transactionId)
         requestQueue.offer(request)
-        OrderPayer.logger.trace("Payment ${createdEvent.paymentId} for order $orderId created.")
-        logger.info("[$accountName] Submitted payment request into queue $paymentId, time spent ${now() - paymentStartedAt} ms")
+        logger.info("[$accountName] Submitted payment request into queue $paymentId, time spent ${now() - paymentStartedAt} ms, queue size ${requestQueue.size}, time needed $timeNeededToProcessQueue")
     }
 
     private suspend fun processRequestQueue() {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -67,6 +67,11 @@ class PaymentExternalSystemAdapterImpl(
     private val maxConcurrentRequests: Int = parallelRequests
     private val requestSemaphore = Semaphore(permits = maxConcurrentRequests)
 
+    @Volatile
+    private var lastRetryAfterTimestamp: Long? = null
+
+    private val queueLock = Any()
+
     init {
         metricsService.registerQueueSizeGauge(accountName, this) { requestQueue.size.toDouble() }
 
@@ -83,33 +88,48 @@ class PaymentExternalSystemAdapterImpl(
         amount: Int,
         paymentStartedAt: Long,
         deadline: Long
-    ) {
-        val transactionId = UUID.randomUUID()
+    ) { 
+        synchronized(queueLock) {
+            val currentTime = now()
 
-        val maxRpsFromConcurrency = maxConcurrentRequests / requestAverageProcessingTime.seconds
-        val effectiveRps = minOf(maxRpsFromConcurrency, rateLimitPerSec.toLong())
+            lastRetryAfterTimestamp?.let { retryAfter ->
+                if (currentTime < retryAfter) {
+                    logger.warn("[$accountName] TooManyRequestsException for payment $paymentId, retry-after time $retryAfter ms (from previous rejection)")
+                    throw TooManyRequestsException("Too many requests", retryAfter)
+                }
+            }
 
-        val timeRemaining = deadline - now()
-        val timeNeededToProcessQueue = ((requestQueue.size.toDouble() / effectiveRps * 1000 + requestAverageProcessingTime.toMillis()) * 1.1).toLong() // in milliseconds
+            val transactionId = UUID.randomUUID()
+            val maxRpsFromConcurrency = maxConcurrentRequests / requestAverageProcessingTime.seconds
+            val effectiveRps = minOf(maxRpsFromConcurrency, rateLimitPerSec.toLong())
 
-        if (timeRemaining <= 0 || timeNeededToProcessQueue > timeRemaining) {
-            val retryAfterTimestamp = now() + timeNeededToProcessQueue
+            val timeRemaining = deadline - currentTime
 
-            logger.warn("[$accountName] TooManyRequestsException for paymemt $paymentId, retry-after time $retryAfterTimestamp ms, queue size ${requestQueue.size}, time needed $timeNeededToProcessQueue")
-            throw TooManyRequestsException("Too many requests", retryAfterTimestamp)
+            // requestAverageProcessingTime.toMillis() == to wait already sended requests
+            // (requestQueue.size + 1 + effectiveRps) / effectiveRps == to process queue with current request added
+            // ceil is needed because we need 2s to process 12 requests with 11rps (11 requests in first sec + 1 request in second sec)
+            val timeNeededToProcessQueueWithNewRequest = (requestQueue.size + effectiveRps) / effectiveRps * 1000 + requestAverageProcessingTime.toMillis() // in milliseconds
+
+            if (timeRemaining <= 0 || timeNeededToProcessQueueWithNewRequest > timeRemaining) {
+                val retryAfterTimestamp = currentTime + timeNeededToProcessQueueWithNewRequest
+                lastRetryAfterTimestamp = retryAfterTimestamp
+
+                logger.warn("[$accountName] TooManyRequestsException for paymemt $paymentId, retry-after time $retryAfterTimestamp ms, queue size ${requestQueue.size}, time needed $timeNeededToProcessQueueWithNewRequest")
+                throw TooManyRequestsException("Too many requests", retryAfterTimestamp)
+            }
+
+            val createdEvent = paymentESService.create {
+                it.create(
+                    paymentId,
+                    orderId,
+                    amount
+                )
+            }
+
+            val request = PaymentRequest(paymentId, amount, paymentStartedAt, deadline, transactionId)
+            requestQueue.offer(request)
+            logger.info("[$accountName] Submitted payment request into queue $paymentId, time spent ${currentTime - paymentStartedAt} ms, queue size ${requestQueue.size}, time needed $timeNeededToProcessQueueWithNewRequest")
         }
-
-        val createdEvent = paymentESService.create {
-            it.create(
-                paymentId,
-                orderId,
-                amount
-            )
-        }
-
-        val request = PaymentRequest(paymentId, amount, paymentStartedAt, deadline, transactionId)
-        requestQueue.offer(request)
-        logger.info("[$accountName] Submitted payment request into queue $paymentId, time spent ${now() - paymentStartedAt} ms, queue size ${requestQueue.size}, time needed $timeNeededToProcessQueue")
     }
 
     private suspend fun processRequestQueue() {

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentServiceImpl.kt
@@ -28,7 +28,6 @@ class PaymentSystemImpl(
                 account.performPaymentAsync(paymentId, orderId, amount, paymentStartedAt, deadline)
                 return
             } catch (e: TooManyRequestsException) {
-                logger.warn("Account ${account.name()} rejected payment $paymentId due to back pressure")
                 // Keep the earliest retry timestamp
                 e.retryAfterTimestamp?.let { timestamp ->
                     if (bestRetryAfterTimestamp == null || timestamp < bestRetryAfterTimestamp!!) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,6 +69,11 @@ metrics:
     description: "payment queue size"
     tags:
       - account
+  external-system-response-time:
+    name: external_system_response_time
+    description: "external system response time in milliseconds"
+    tags:
+      - account
 
 thread-pools:
   payment-external-service-thread-pool-config:


### PR DESCRIPTION
#  Аккаунт
Аккаунт: "acc-23"
```json
  {
    "accountName": "acc-23",
    "parallelRequests": 64,
    "rateLimitPerSec": 11,
    "price": 30,
    "averageProcessingTime": "PT1S"
  }
```
---
# Тест №1
```json
{
  "ratePerSecond": 15,
  "testCount": 3000,
  "processingTimeMillis": 2500
}
```
## В чем была проблема
При запуске тестов сразу появляются проваленные оплаты. 2000/3000 тестов не проходят.
[Графики](http://77.234.215.138:33000/d/KVr-Vmpnz/services-statistic?orgId=1&from=2025-10-19T11:01:00.000Z&to=2025-10-19T11:08:59.000Z&timezone=browser&var-service=pelmeni&refresh=5s)
<img width="2462" height="1594" alt="image" src="https://github.com/user-attachments/assets/4386bcf3-79e9-4620-bb85-1e8609d48d32" />
<img width="2462" height="1594" alt="image" src="https://github.com/user-attachments/assets/f0f42401-fb5c-40e1-80ba-fb76c2c05675" />


## Гипотеза почему это происходит

Наш сервис имеет постоянную нагрузку в `15 rps`, при этом внешний сервис имеет `11 rps` и среднее время обработки в 1 секунду. То есть у нас будет накапливаться постоянно очередь со скоростью `4 rps`. И поэтому почти сразу некоторая часть оплаты проваливается, ибо запросы находятся в очереди > 1.5 секунд (`2.5 секунды максимум будет ждать клиент - (1 секунда на обработку оплаты  + delta погрешности`)

## Решение
Решения нет, т.к. пропускная способность внешнего сервиса меньше пропускной способности нашего сервиса, а также то, что время ожидания клиентов крайне мала, чтобы успевать обработать очередь с постоянным накоплением в `4 rps`

---
# Тест №2
```json
{
  "ratePerSecond": 11,
  "testCount": 2200,
  "processingTimeMillis": 13000,
  "profile": "s_0.7_60"
}
```

## В чем была проблема
<img width="315" height="165" alt="image" src="https://github.com/user-attachments/assets/ddaa771e-0958-4ccd-aaa9-b86a1767ff05" />

Текущее решение удовлетворяет результату, который подходит под ориентир:
```
Время выполнение 3.5 минуты (у нас примерно 3.5 минуты)
Fail / Success 42 / 2230 (У нас 49 / 2235)
Income / Expenses 892k / 68k (919k / 68.5k)
```
[Графики](http://77.234.215.138:33000/d/KVr-Vmpnz/services-statistic?orgId=1&from=2025-10-18T21:13:00.000Z&to=2025-10-18T21:17:30.000Z&timezone=browser&var-service=pelmeni&refresh=5s)
<img width="2462" height="1594" alt="image" src="https://github.com/user-attachments/assets/1f5c019c-8238-46dc-ae5c-c87a4c754907" />
<img width="2462" height="1594" alt="image" src="https://github.com/user-attachments/assets/5c9e3a8d-d1a1-49d4-8d2f-8b96937d7f60" />

## Гипотеза почему это происходит
Наш сервис и внешний сервис имееют одинаковую постоянную нагрузку в `11 rps`. Теоритически очередь накапливаться не должна. Время ожидания клиентов довольно большая, что текущее решение позволяет не проваливаться на таймаутах клиентов.

У нас есть предположение, что параметр `"profile"` отвечает за то, как именно распределяется нагрузка. В нашем случае это график тригонометрической функции. При этом загрузка внешнего сервиса постоянно высокая.

Из-за того, что функция нагрузки не линейная, а тригонометрическая и имеет пики, то в некоторые моменты времени приходят больше клиентов, что они отпадают по таймауту, и в таком случае очередь накапливается, но через некоторое время в миниуме функции, она полностью обработана.

<img width="2462" height="1594" alt="image" src="https://github.com/user-attachments/assets/aa129941-caef-47b7-bdcf-28f4995562b1" />

## Решение

Работает и не трогаем :D
<img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/95315f39-8137-4411-a2c7-238e65deec47" />


---
# Тест №3
```json
{
  "ratePerSecond": 3,
  "testCount": 1050,
  "processingTimeMillis": 26000,
  "runits": 90
}
```

## В чем была проблема
<img width="315" height="165" alt="image" src="https://github.com/user-attachments/assets/ddaa771e-0958-4ccd-aaa9-b86a1767ff05" />

Текущее решение удовлетворяет результату, который подходит под ориентир:
```
Время выполнение 6 минут (у нас примерно 6 минуты)
Fail / Success 2 / 1060 (У нас 0 / 1078)
Income / Expenses 428k / 31.9k (442k / 32.3k)
```
[Графики](http://77.234.215.138:33000/d/KVr-Vmpnz/services-statistic?orgId=1&from=2025-10-21T16:36:30.000Z&to=2025-10-21T16:43:00.000Z&timezone=browser&var-service=pelmeni&refresh=5s)
<img width="2462" height="1479" alt="image" src="https://github.com/user-attachments/assets/df445aec-7ebf-46e3-b7b3-6dc63477814a" />
<img width="2462" height="1479" alt="image" src="https://github.com/user-attachments/assets/6dcc54c3-fe57-45a7-ac9b-a32540803051" />


## Гипотеза почему это происходит
На первый взгляд, наш сервис имеет в среднем постоянную нагрузку в `3 rps`. Очередь не накапливается. Время ожидания клиентов очень большая, что текущее решение позволяет не проваливаться на таймаутах клиентов.
Однако параметр "runits": 90 добавляет условия, что раз в 90 секунд, максимальную нагрузку (пики видны на графике), даже при таком сценарии сервис корректно обрабатывает запросы без ошибок.

Нагрузка на внешний клиент постоянно максимальна
<img width="2462" height="1479" alt="image" src="https://github.com/user-attachments/assets/db11ecda-5e82-44af-a077-84f8e6cfb286" />


## Решение

Работает и не трогаем :D
<img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/95315f39-8137-4411-a2c7-238e65deec47" />
