### PR TITLE
Hw 07

### DIFF
--- a/src/main/kotlin/ru/quipy/config/MetricsConfig.kt
+++ b/src/main/kotlin/ru/quipy/config/MetricsConfig.kt
@@ -6,15 +6,25 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 @ConfigurationProperties("metrics")
 class MetricsConfig(
-    var incomingRequests: MetricProperties = MetricProperties(),
-    var outgoingResponses: MetricProperties = MetricProperties(),
-    var completedTasks: MetricProperties = MetricProperties(),
-    var queueSize: MetricProperties = MetricProperties(),
-    var externalSystemResponseTime: MetricProperties = MetricProperties(),
+    var incomingRequests: CounterProperties = CounterProperties(),
+    var outgoingResponses: CounterProperties = CounterProperties(),
+    var completedTasks: CounterProperties = CounterProperties(),
+    var queueSize: GaugeProperties = GaugeProperties(),
+    var externalSystemResponseTime: TimerProperties = TimerProperties(),
+    var externalSystemSinglePaymentRetries: CounterProperties = CounterProperties(),
 ) {
-    data class MetricProperties(
+    open class CommonMetricProperties(
         var name: String = "defaultName",
         var description: String = "defaultDescription",
-        var tags: List<String> = emptyList(),
     )
+
+    data class CounterProperties(
+        var tags: List<String> = emptyList(),
+    ): CommonMetricProperties()
+
+    class GaugeProperties: CommonMetricProperties()
+
+    data class TimerProperties(
+        var quantiles: List<Double> = emptyList(),
+    ): CommonMetricProperties()
 }

--- a/src/main/kotlin/ru/quipy/config/RetriesConfig.kt
+++ b/src/main/kotlin/ru/quipy/config/RetriesConfig.kt
@@ -1,0 +1,14 @@
+package ru.quipy.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties("retries")
+class RetriesConfig(
+    var payment: MaxRetryConfig = MaxRetryConfig()
+) {
+    data class MaxRetryConfig(
+        var maxRetries: Int = -1,
+    )
+}

--- a/src/main/kotlin/ru/quipy/metrics/MetricsService.kt
+++ b/src/main/kotlin/ru/quipy/metrics/MetricsService.kt
@@ -12,6 +12,10 @@ import ru.quipy.config.MetricsConfig
 class MetricsService(
     val metricsConfig: MetricsConfig,
 ) {
+    companion object {
+        const val ACCOUNT_TAG = "account"
+    }
+
     fun <T> runWithMetric(tags: List<String>, block: () -> T): T {
         if (tags.size != metricsConfig.incomingRequests.tags.size) {
             throw RuntimeException("Incorrect size of provided tags")
@@ -27,25 +31,30 @@ class MetricsService(
     }
 
     fun registerQueueSizeGauge(accountName: String, gaugeObject: Any, valueFunction: () -> Double) {
-        val tags = listOf(Tag.of("account", accountName))
+        val tags = listOf(Tag.of(ACCOUNT_TAG, accountName))
         Gauge.builder(metricsConfig.queueSize.name, gaugeObject) { valueFunction() }
             .description(metricsConfig.queueSize.description)
             .tags(tags)
             .register(Metrics.globalRegistry)
     }
 
+    fun registerExternalSystemRetries(accountName: String, value: Int) {
+        val tags = listOf(accountName, value.toString())
+        registerCounter(metricsConfig.externalSystemSinglePaymentRetries, tags).increment()
+    }
+
     fun recordExternalSystemResponseTime(accountName: String, durationMillis: Long) {
-        val tags = listOf(Tag.of("account", accountName))
+        val tags = listOf(Tag.of(ACCOUNT_TAG, accountName))
         val timer = Timer
             .builder(metricsConfig.externalSystemResponseTime.name)
             .description(metricsConfig.externalSystemResponseTime.description)
             .tags(tags)
-            .publishPercentiles(0.5, 0.75, 0.9, 0.95, 0.99)
+            .publishPercentiles(*metricsConfig.externalSystemResponseTime.quantiles.toDoubleArray())
             .register(Metrics.globalRegistry)
         timer.record(durationMillis, java.util.concurrent.TimeUnit.MILLISECONDS)
     }
 
-    private fun registerCounter(config: MetricsConfig.MetricProperties, tags: List<String>): Counter {
+    private fun registerCounter(config: MetricsConfig.CounterProperties, tags: List<String>): Counter {
         val counterTags: List<Tag> =
             config.tags.mapIndexed { index, element ->
                 Tag.of(element, tags[index])

--- a/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
+++ b/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import ru.quipy.config.RetriesConfig
 import ru.quipy.config.ThreadPoolsConfig
 import ru.quipy.core.EventSourcingService
 import ru.quipy.metrics.MetricsService
@@ -42,6 +43,7 @@ class PaymentAccountsConfig {
         paymentService: EventSourcingService<UUID, PaymentAggregate, PaymentAggregateState>,
         threadPoolsConfig: ThreadPoolsConfig,
         metricsService: MetricsService,
+        retiesConfig: RetriesConfig,
     ): List<PaymentExternalSystemAdapter> {
         val request = HttpRequest.newBuilder()
             .uri(URI("http://${paymentProviderHostPort}/external/accounts?serviceName=$serviceName&token=$token"))
@@ -66,6 +68,7 @@ class PaymentAccountsConfig {
                     token,
                     threadPoolsConfig,
                     metricsService,
+                    retiesConfig,
                 )
             }
     }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -8,30 +8,23 @@ import kotlinx.coroutines.sync.withPermit
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okio.withLock
 import org.slf4j.LoggerFactory
 import ru.quipy.common.utils.SlidingWindowRateLimiter
+import ru.quipy.config.RetriesConfig
 import ru.quipy.config.ThreadPoolsConfig
 import ru.quipy.core.EventSourcingService
 import ru.quipy.metrics.MetricsService
 import ru.quipy.payments.api.PaymentAggregate
-import java.net.SocketTimeoutException
+import java.io.InterruptedIOException
 import java.util.*
-import java.util.concurrent.BlockingQueue
 import java.util.concurrent.Executors
-import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.locks.ReentrantLock
 import kotlin.math.ceil
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
-
-data class PaymentRequest(
-    val paymentId: UUID,
-    val orderId: UUID,
-    val amount: Int,
-    val paymentStartedAt: Long,
-    val deadline: Long,
-    val transactionId: UUID
-)
 
 // Advice: always treat time as a Duration
 class PaymentExternalSystemAdapterImpl(
@@ -40,7 +33,8 @@ class PaymentExternalSystemAdapterImpl(
     private val paymentProviderHostPort: String,
     private val token: String,
     private val threadPoolsConfig: ThreadPoolsConfig,
-    private val metricsService: MetricsService
+    private val metricsService: MetricsService,
+    private val retriesConfig: RetriesConfig,
 ) : PaymentExternalSystemAdapter {
 
     companion object {
@@ -79,9 +73,9 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val client = OkHttpClient.Builder().build()
+    private val client = OkHttpClient.Builder().callTimeout(requestAverageProcessingTime).build()
     private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), 1.seconds.toJavaDuration())
-    private val requestQueue: BlockingQueue<PaymentRequest> = LinkedBlockingQueue()
+    private val requestQueue: PaymentQueue = PaymentQueue(retriesConfig.payment.maxRetries)
 
     private val executorThreadNumber = threadPoolsConfig.paymentExternalServiceThreadPoolConfig.threadsNumber
     private val executorService = Executors.newFixedThreadPool(executorThreadNumber)
@@ -93,8 +87,7 @@ class PaymentExternalSystemAdapterImpl(
     @Volatile
     private var lastRetryAfterTimestamp: Long? = null
 
-    private val queueLock = Any()
-    private val retriedPayments = Collections.synchronizedSet(HashSet<UUID>())
+    private val queueLock = ReentrantLock()
 
     init {
         metricsService.registerQueueSizeGauge(accountName, this) { requestQueue.size.toDouble() }
@@ -113,7 +106,7 @@ class PaymentExternalSystemAdapterImpl(
         paymentStartedAt: Long,
         deadline: Long
     ) { 
-        synchronized(queueLock) {
+        queueLock.withLock {
             val currentTime = now()
 
             lastRetryAfterTimestamp?.let { retryAfter ->
@@ -141,7 +134,7 @@ class PaymentExternalSystemAdapterImpl(
                 throw TooManyRequestsException("Too many requests", lastRetryAfterTimestamp)
             }
 
-            if (!retriedPayments.contains(paymentId)) {
+            if (!requestQueue.containsByPaymentId(paymentId)) {
                 val createdEvent = paymentESService.create {
                     it.create(
                         paymentId,
@@ -211,13 +204,25 @@ class PaymentExternalSystemAdapterImpl(
 
         val requestStartTime = now()
         try {
-            val response = withContext(Dispatchers.IO) {
-                client.newCall(httpRequest).execute()
+            val response: Response? = withContext(Dispatchers.IO) {
+                try {
+                    client.newCall(httpRequest).execute()
+                } catch (e: Exception) {
+                    when (e) {
+                        is InterruptedIOException -> {
+                            logger.info("[$accountName] Payment timeout for txId: ${request.transactionId}, payment: ${request.paymentId}, time spent ${requestAverageProcessingTime.toMillis()} ms")
+                            val newRequest = request.copy(retries = request.retries + 1)
+                            requestQueue.offer(newRequest)
+                            null
+                        }
+                        else -> throw e
+                    }
+                }
             }
             val responseTime = now() - requestStartTime
             metricsService.recordExternalSystemResponseTime(accountName, responseTime)
 
-            response.use { resp ->
+            response?.let { resp ->
                 val body = try {
                     mapper.readValue(resp.body?.string(), ExternalSysResponse::class.java)
                 } catch (e: Exception) {
@@ -229,6 +234,7 @@ class PaymentExternalSystemAdapterImpl(
                         e.message
                     )
                 }
+                metricsService.registerExternalSystemRetries(accountName, request.retries)
 
                 logger.info("[$accountName] Payment processed for txId: ${request.transactionId}, payment: ${request.paymentId}, succeeded: ${body.result}, result code: ${resp.code}, message: ${body.message}, time spent ${now() - request.paymentStartedAt} ms")
 
@@ -239,39 +245,12 @@ class PaymentExternalSystemAdapterImpl(
                         it.logProcessing(body.result, now(), request.transactionId, reason = body.message)
                     }
                 }
-                
-                // Если это был ретрай, удаляем payment из HashSet
-                if (retriedPayments.contains(request.paymentId)) {
-                    retriedPayments.remove(request.paymentId)
-                } else if (!body.result && !retryForbiddenCodes.contains(resp.code)) {
-                    // Если результат неуспешный и для этого payment еще не было ретрая, пробуем сделать ретрай
-                    retriedPayments.add(request.paymentId)
-                    try {
-                        performPaymentAsync(request.paymentId, request.orderId, request.amount, request.paymentStartedAt, request.deadline)
-                        logger.info("[$accountName] Retry submitted for payment ${request.paymentId}, txId: ${request.transactionId}")
-                    } catch (e: Exception) {
-                        retriedPayments.remove(request.paymentId)
-                        logger.warn("[$accountName] Retry failed for payment ${request.paymentId}, txId: ${request.transactionId}", e)
-                    }
-                }
             }
         } catch (e: Exception) {
             val responseTime = now() - requestStartTime
             metricsService.recordExternalSystemResponseTime(accountName, responseTime)
             
             when (e) {
-                is SocketTimeoutException -> {
-                    logger.error(
-                        "[$accountName] Payment timeout for txId: ${request.transactionId}, payment: ${request.paymentId}, time spent ${now() - request.paymentStartedAt} ms",
-                        e
-                    )
-                    withContext(Dispatchers.IO) {
-                        paymentESService.update(request.paymentId) {
-                            it.logProcessing(false, now(), request.transactionId, reason = "Request timeout.")
-                        }
-                    }
-                }
-
                 else -> {
                     logger.error(
                         "[$accountName] Payment failed for txId: ${request.transactionId}, payment: ${request.paymentId}, time spent ${now() - request.paymentStartedAt} ms",

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentQueue.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentQueue.kt
@@ -1,0 +1,27 @@
+package ru.quipy.payments.logic
+
+import java.util.*
+import java.util.concurrent.LinkedBlockingQueue
+
+data class PaymentRequest(
+    val paymentId: UUID,
+    val orderId: UUID,
+    val amount: Int,
+    val paymentStartedAt: Long,
+    val deadline: Long,
+    val transactionId: UUID,
+    val retries: Int = 0,
+)
+
+class PaymentQueue(
+    private val maxRetries: Int = -1,
+): LinkedBlockingQueue<PaymentRequest>() {
+    override fun offer(e: PaymentRequest): Boolean {
+        if (maxRetries > 0 && e.retries > maxRetries) {
+            return false
+        }
+        return super.offer(e)
+    }
+
+    fun containsByPaymentId(paymentId: UUID) = this.any { it.paymentId == paymentId }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,14 +67,21 @@ metrics:
   queue-size:
     name: payment_queue_size
     description: "payment queue size"
-    tags:
-      - account
   external-system-response-time:
     name: external_system_response_time
     description: "external system response time in milliseconds"
+    quantiles: 0.5, 0.75, 0.9, 0.95, 0.99
+  external-system-single-payment-retries:
+    name: external_system_single_payment_retries
+    description: "external system calls for one payment before succesfull response"
     tags:
       - account
+      - retries_count
 
 thread-pools:
   payment-external-service-thread-pool-config:
     threads-number: 16
+
+retries:
+  payment:
+    max-retries: 5


### PR DESCRIPTION
# Аккаунт
Аккаунт: "acc-7"
```
{
  "accountName": "acc-7",
  "parallelRequests": 50,
  "rateLimitPerSec": 8,
  "price": 30,
  "averageProcessingTime": 1.2S
}
```
# Тест
```
  "ratePerSecond": 5,
  "testCount": 1000,
  "processingTimeMillis": 6000
```
## В чем была проблема
При запуске тестов некоторое количество тестов выполнялось гораздо больше среднего времени выполнения. Был построен график времени выполнения запроса, по 90-му перцентилю время выполнения было 10 секунд, т.к. в этот момент соединение уже прерывалось. Запрос держал подключение и вылезал за пределы ожидания processingTimeMillis + это возимело эффект на другие запросы, т.к. существует ограничение на количество параллельных запросов
<img width="1519" height="728" alt="image" src="https://github.com/user-attachments/assets/9718e6d3-a117-4e70-bfbc-77f6c592c872" />
## Решение
Добавили таймаут на выполнение запроса. Было выбрано значение в averageProcessingTime. Так же увеличили количество ретраев, т.к. были запросы, которые и при второй попытке могли выполняться долго. Так же добавили метрику на количество ретраев до успешного выполнения
## Графики
### До
<img width="1582" height="616" alt="image" src="https://github.com/user-attachments/assets/59a97a04-6985-45d2-a30e-5e4bcaa409c7" />
<img width="1587" height="651" alt="image" src="https://github.com/user-attachments/assets/9c612e73-8e58-4696-b261-890f19a730f8" />

### После
<img width="1582" height="614" alt="image" src="https://github.com/user-attachments/assets/66fc921b-6acb-4657-ad68-d78118337709" />
<img width="1584" height="648" alt="image" src="https://github.com/user-attachments/assets/f38c305e-dd2a-4f16-8123-64d2ab855ce6" />
<img width="1578" height="310" alt="image" src="https://github.com/user-attachments/assets/eab6b00f-a152-4732-8b4f-47aa66e42d46" />

#### Запросы для построения графиков
`external_system_response_time_seconds`
`round(increase(external_system_single_payment_retries_total[$__range]))` - тип графика `stat`