### PR TITLE
hw-08

### DIFF
--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -73,7 +73,7 @@ class PaymentExternalSystemAdapterImpl(
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
 
-    private val client = OkHttpClient.Builder().callTimeout(requestAverageProcessingTime).build()
+    private val client = OkHttpClient.Builder().callTimeout(requestAverageProcessingTime.multipliedBy(2)).build()
     private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), 1.seconds.toJavaDuration())
     private val requestQueue: PaymentQueue = PaymentQueue(retriesConfig.payment.maxRetries)
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,7 +42,7 @@ event:
 
 payment:
   hostPort: ${PAYMENT_HOST:localhost}:${PAYMENT_PORT:1234}
-  accounts: ${PAYMENT_ACCOUNTS:acc-12,acc-20}
+  accounts: ${PAYMENT_ACCOUNTS:acc-9}
   token: ${PAYMENT_TOKEN}
   service-name: ${PAYMENT_SERVICE_NAME}
 
@@ -80,7 +80,7 @@ metrics:
 
 thread-pools:
   payment-external-service-thread-pool-config:
-    threads-number: 16
+    threads-number: 50
 
 retries:
   payment:


### PR DESCRIPTION
# Аккаунт
Аккаунт: "acc-9"
```
{
  "accountName": "acc-9",
  "parallelRequests": 50,
  "rateLimitPerSec": 120,
  "price": 30,
  "averageProcessingTime": 0.5S
}
```
# Тест
```
  "ratePerSecond": 100,
  "testCount": 5000,
  "processingTimeMillis": 20000
```

## В чем была проблема
При запуске теста разростался размер очереди и из-за этого появлялись client timeout. Что странно, ведь с ограничениями теста в нас должно приходить ровно 100rps и мы в свою очередь можем отправлять во внешний сервис 100rps (50 параллельных запросов за 0.5с = 50 + 50 за секунду = 100 за секунду)

<img width="1982" height="1028" alt="image" src="https://github.com/user-attachments/assets/c1a6c2d0-6c08-4666-9936-f93d8ddecee8" />

## Решение

Сервис просто не успевает обрабатывать запросы. У нас на обработку запросов заведен тредпул на 16 потоков. 16 потоков не справляются с параллельными 50 запросами. Подняли число потоков до 50 и  всё заработало

### Идеи по улучшению

На самом деле нужен не простой тредпул, а CoroutineDispatcher. То есть тредпул, внутри которого крутятся корутины. 

Зачем так сделано - специфика сервиса такая, что поток обрабатывающий запрос из очереди 90% времени спит. Сначала он спит на ожидании запроса в очереди. Потом она делает простое действие - отправляет http запрос - и снова спит. Затем получает ответ и делает запись в базу данных (paymentESService.update), то есть снова спит. Очевидно хочется иметь 16 потоков и 50 корутин на этих потоках, которые переключались бы между собой во время сна. Но сейчас хоть и используется CoroutineDispatcher, некоторые операции не работают с корутинами и вместо suspend усыпляют поток. В последующих работах нужно будет это исправить, 50 потоков это ок, а 5000 уже не ок, при том что в теории сервис может спокойно держать 5000 рпс на 128 потоках, тк почти не делает полезной нагрузки

## Графики
### До

<img width="1982" height="1028" alt="image" src="https://github.com/user-attachments/assets/7e23e54a-b7c9-4eff-b5d5-e06750336e63" />

<img width="1977" height="1042" alt="image" src="https://github.com/user-attachments/assets/144e6881-03a2-4a39-af3a-27fbfc11b91c" />


### После

<img width="2003" height="1130" alt="image" src="https://github.com/user-attachments/assets/b6d717c8-1a5c-40f4-a868-fd70e98c02d9" />

<img width="1991" height="1047" alt="image" src="https://github.com/user-attachments/assets/be3e2553-2f31-46a5-ad67-c4d56c11f06c" />


#### Запросы для построения графиков
`external_system_response_time_seconds`
`round(increase(external_system_single_payment_retries_total[$__range]))` - тип графика `stat`