### PR TITLE
fix time to process queue computation

### DIFF
--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -93,7 +93,7 @@ class PaymentExternalSystemAdapterImpl(
 
     private val httpClient = HttpClient.create()
         .protocol(HttpProtocol.H2C)
-        .responseTimeout(Duration.ofMillis(requestAverageProcessingTime.multipliedBy(2).toMillis()))
+        .responseTimeout(Duration.ofMillis(maxOf(requestAverageProcessingTime.multipliedBy(2).toMillis(), 500)))
 
     private val webClient = WebClient.builder()
         .clientConnector(ReactorClientHttpConnector(httpClient))
@@ -118,9 +118,12 @@ class PaymentExternalSystemAdapterImpl(
     private var lastRetryAfterTimestamp: Long? = null
 
     private val queueLock = ReentrantLock()
-    
+
     @Volatile
     private var lastQueueLogTime: Long = 0
+
+    private val timeToProcessCounter =
+        TimeToProcessCounter(requestAverageProcessingTime, maxConcurrentRequests, rateLimitPerSec)
 
     init {
         metricsService.registerQueueSizeGauge(accountName, this) { requestQueue.size().toDouble() }
@@ -150,18 +153,9 @@ class PaymentExternalSystemAdapterImpl(
                 }
             }
 
-            val maxRpsFromConcurrency =
-                maxConcurrentRequests.toDouble() / requestAverageProcessingTime.toMillis().toDouble() * 1000
-            val effectiveRps = minOf(maxRpsFromConcurrency, rateLimitPerSec.toDouble())
-
             val timeRemaining = deadline - currentTime
 
-            // requestAverageProcessingTime.toMillis() == to wait already sended requests
-            // (requestQueue.size + 1 + effectiveRps) / effectiveRps == to process queue with current request added
-            // ceil is needed because we need 2s to process 12 requests with 11rps (11 requests in first sec + 1 request in second sec)
-            val timeNeededToProcessQueueWithNewRequest = ceil(
-                (requestQueue.size().toDouble() + 1) / effectiveRps
-            ).toLong() * 1000 + requestAverageProcessingTime.toMillis() // in milliseconds
+            val timeNeededToProcessQueueWithNewRequest = timeToProcessCounter.computeTimeToProcessQueue(requestQueue.size() + 1).toMillis()
 
             if (timeRemaining <= 0 || timeNeededToProcessQueueWithNewRequest + 100 > timeRemaining) {
                 lastRetryAfterTimestamp = currentTime + timeNeededToProcessQueueWithNewRequest
@@ -263,7 +257,7 @@ class PaymentExternalSystemAdapterImpl(
                         .retrieve()
                         .toEntity(String::class.java)
                         .awaitSingle()
-                    
+
                     Pair(response.body ?: "", response.statusCode.value())
                 } catch (e: Exception) {
                     when (e) {
@@ -276,6 +270,7 @@ class PaymentExternalSystemAdapterImpl(
                             requestQueue.offer(newRequest)
                             null
                         }
+
                         is WebClientRequestException, is ConnectException, is IOException -> {
                             log(
                                 request.paymentId,
@@ -286,9 +281,11 @@ class PaymentExternalSystemAdapterImpl(
                             requestQueue.offer(newRequest)
                             null
                         }
+
                         is WebClientResponseException -> {
                             Pair(e.responseBodyAsString, e.statusCode.value())
                         }
+
                         else -> throw e
                     }
                 }
@@ -358,7 +355,7 @@ class PaymentExternalSystemAdapterImpl(
 
     override fun name() = properties.accountName
 
-    private fun log(paymentId: UUID , msg: String) {
+    private fun log(paymentId: UUID, msg: String) {
         if (logConfig.enabled && paymentId.hashCode().absoluteValue % logConfig.sample == 0) {
             logger.info(msg)
         }

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentQueue.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentQueue.kt
@@ -3,9 +3,12 @@ package ru.quipy.payments.logic
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import java.time.Duration
 import java.util.*
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.collections.ArrayDeque
+import kotlin.math.ceil
 
 data class PaymentRequest(
     val paymentId: UUID,

--- a/src/main/kotlin/ru/quipy/payments/logic/TimeToProcessCounter.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/TimeToProcessCounter.kt
@@ -1,0 +1,64 @@
+package ru.quipy.payments.logic
+
+import org.slf4j.LoggerFactory
+import java.time.Duration
+
+class TimeToProcessCounter(
+    public val requestAverageProcessingTime: Duration,
+    public val maxConcurrentRequests: Int,
+    public val rateLimitPerSec: Int,
+) {
+    companion object {
+        val logger = LoggerFactory.getLogger(TimeToProcessCounter::class.java)
+
+        private const val precomputeLimit = 1_000_000
+    }
+
+    private val observations = ArrayList<Observation>()
+
+
+    init {
+        var processedRequests = 0
+        var parallelRequests = 0
+        var requestsInPrevSecond = 0
+        var currentTime = Duration.ZERO
+        var rpsDeque = ArrayDeque<Observation>()
+        var parallelDeque = ArrayDeque<Observation>()
+
+        while (processedRequests < precomputeLimit) {
+            while (rpsDeque.size > 0 && currentTime - rpsDeque.first().time > Duration.ofSeconds(1)) {
+                requestsInPrevSecond -= rpsDeque.removeFirst().requestsCount
+            }
+            while (parallelDeque.size > 0 && currentTime - parallelDeque.first().time > requestAverageProcessingTime) {
+                parallelRequests -= parallelDeque.removeFirst().requestsCount
+            }
+            if (requestsInPrevSecond == rateLimitPerSec) {
+                currentTime = rpsDeque.first().time + Duration.ofSeconds(1) + Duration.ofMillis(1)
+                continue
+            }
+            if (parallelRequests == maxConcurrentRequests) {
+                currentTime = parallelDeque.first().time + requestAverageProcessingTime + Duration.ofMillis(1)
+                continue
+            }
+            val toSend = minOf(maxConcurrentRequests - parallelRequests, rateLimitPerSec - requestsInPrevSecond)
+            processedRequests += toSend
+            parallelRequests += toSend
+            requestsInPrevSecond += toSend
+            observations.add(Observation(processedRequests, currentTime))
+            rpsDeque.add(Observation(toSend, currentTime))
+            parallelDeque.add(Observation(toSend, currentTime))
+        }
+        logger.info("Precomputed processing times for requestAverageProcessingTime=$requestAverageProcessingTime, maxConcurrentRequests=$maxConcurrentRequests, rateLimitPerSec=$rateLimitPerSec, first values = [${observations[0]}, ${observations[1]}, ${observations[2]}, ${observations[3]}, ${observations[4]}]")
+    }
+
+    public fun computeTimeToProcessQueue(queueSize: Int): Duration {
+        val index = observations.binarySearch { it.requestsCount.compareTo(queueSize) }
+        val sendTime = if (index >= 0) observations[index].time else observations[-index - 1].time
+        return sendTime + requestAverageProcessingTime
+    }
+
+    data class Observation(
+        val requestsCount: Int,
+        val time: Duration,
+    )
+}


### PR DESCRIPTION
Кейс

Аккаунт: "acc-13"

```json
{  
  "ratePerSecond": 4000,
  "testCount": 1500000,
  "processingTimeMillis": 1000
}
```

```accountName=acc-13, parallelRequests=2000, rateLimitPerSec=5000, price=30, averageProcessingTime=PT0.01S```

## В чем была проблема

1) Экстремально маленький averageProcessingTime. Сломалась формула расчета времени для процессинга размера очереди. Из-за этого сервис на каждые 300 рпс говорил 429

Решение - сделали совсем другой механизм расчета. Теперь время на процессинг очереди предпосчитывается при старте сервиса. Придумать формулу для всех случаев очень трудно (и возможно её не существует)

Например занимательный случай - averageProcessingTime 2.39S, rateLimitPerSec=761, parallelRequests=1337

2) У нас выставлялся таймаут на http запросы 2*averageProcessingTime. Здесь опять же из-за очень маленького averageProcessingTime это работало криво и сервис таймаутил каждый второй запрос. Сделали лимит maxOf(2*averageProcessingTime, 500ms)

Пример вывода препроцессинга

```
first values = [Observation(requestsCount=2000, time=PT0S), Observation(requestsCount=4000, time=PT0.011S), Observation(requestsCount=5000, time=PT0.022S), Observation(requestsCount=7000, time=PT1.001S), Observation(requestsCount=9000, time=PT1.012S)]
```