### PR TITLE
Hw 11

### DIFF
--- a/src/main/kotlin/ru/quipy/config/HedgedRequestsConfig.kt
+++ b/src/main/kotlin/ru/quipy/config/HedgedRequestsConfig.kt
@@ -1,0 +1,11 @@
+package ru.quipy.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties("hedged-requests")
+data class HedgedRequestsConfig(
+    var tries: Int = 1,
+    var delay: Long = 500,
+)

--- a/src/main/kotlin/ru/quipy/config/QueueSimulationConfig.kt
+++ b/src/main/kotlin/ru/quipy/config/QueueSimulationConfig.kt
@@ -1,0 +1,10 @@
+package ru.quipy.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties("queue-simulation")
+data class QueueSimulationConfig(
+    var enabled: Boolean = false
+)

--- a/src/main/kotlin/ru/quipy/config/ThreadPoolsConfig.kt
+++ b/src/main/kotlin/ru/quipy/config/ThreadPoolsConfig.kt
@@ -6,11 +6,16 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 @ConfigurationProperties("thread-pools")
 data class ThreadPoolsConfig(
-    var paymentExternalServiceThreadPoolConfig: ThreadPoolProperties = ThreadPoolProperties()
+    var paymentExternalServiceThreadPoolConfig: ThreadPoolProperties = ThreadPoolProperties(),
+    var parallelIdempotencyRequestsExecutorServiceThreadPoolConfig: ParallelIdempotencyRequestsExecutorServiceThreadPoolConfig = ParallelIdempotencyRequestsExecutorServiceThreadPoolConfig(),
 ) {
     data class ThreadPoolProperties(
         var threadsNumber: Int = 1,
         var backgroundTaskThreadsNumber: Int = 1,
         var requestHandlerThreadsNumber: Int = 32
+    )
+
+    data class ParallelIdempotencyRequestsExecutorServiceThreadPoolConfig(
+        var threadsNumber: Int = 1,
     )
 }

--- a/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
+++ b/src/main/kotlin/ru/quipy/payments/config/PaymentAccountsConfig.kt
@@ -6,10 +6,7 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import ru.quipy.config.BackPressureConfig
-import ru.quipy.config.LogConfig
-import ru.quipy.config.RetriesConfig
-import ru.quipy.config.ThreadPoolsConfig
+import ru.quipy.config.*
 import ru.quipy.core.EventSourcingService
 import ru.quipy.metrics.MetricsService
 import ru.quipy.payments.api.PaymentAggregate
@@ -48,6 +45,8 @@ class PaymentAccountsConfig {
         retiesConfig: RetriesConfig,
         logConfig: LogConfig,
         backPressureConfig: BackPressureConfig,
+        queueSimulationConfig: QueueSimulationConfig,
+        hedgedRequestsConfig: HedgedRequestsConfig,
     ): List<PaymentExternalSystemAdapter> {
         val request = HttpRequest.newBuilder()
             .uri(URI("http://${paymentProviderHostPort}/external/accounts?serviceName=$serviceName&token=$token"))
@@ -74,7 +73,9 @@ class PaymentAccountsConfig {
                     metricsService,
                     retiesConfig,
                     logConfig,
-                    backPressureConfig
+                    backPressureConfig,
+                    queueSimulationConfig,
+                    hedgedRequestsConfig,
                 )
             }
     }

--- a/src/main/kotlin/ru/quipy/payments/logic/ParallelIdempotencyRequestsExecutorService.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/ParallelIdempotencyRequestsExecutorService.kt
@@ -1,0 +1,110 @@
+package ru.quipy.payments.logic
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.reactor.awaitSingle
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.HttpProtocol
+import reactor.netty.http.client.HttpClient
+import ru.quipy.common.utils.SlidingWindowRateLimiter
+import ru.quipy.config.LogConfig
+import ru.quipy.config.ThreadPoolsConfig
+import java.time.Duration
+import java.util.*
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.math.absoluteValue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+class ParallelIdempotencyRequestsExecutorService(
+    private val threadPoolsConfig: ThreadPoolsConfig,
+    private val tries: Int,
+    private val delayTime: Long,
+    private val properties: PaymentAccountProperties,
+    private val logConfig: LogConfig,
+) {
+    private val logger = LoggerFactory.getLogger(ParallelIdempotencyRequestsExecutorService::class.java)
+
+    private val requestAverageProcessingTime = properties.averageProcessingTime
+    private val rateLimitPerSec = properties.rateLimitPerSec
+    private val parallelRequests = properties.parallelRequests
+    private val maxParallelRequestsCount =
+        maxOf(parallelRequests, rateLimitPerSec * maxOf(1, requestAverageProcessingTime.toSeconds().toInt()))
+
+    private val httpClient = HttpClient.create()
+        .protocol(HttpProtocol.H2C)
+        .responseTimeout(Duration.ofMillis(maxOf(requestAverageProcessingTime.multipliedBy(2).toMillis(), 500)))
+    private val webClient = WebClient.builder()
+        .clientConnector(ReactorClientHttpConnector(httpClient))
+        .build()
+
+    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), 1.seconds.toJavaDuration())
+    private val requestSemaphore = Semaphore(permits = parallelRequests)
+
+    suspend fun executePaymentCall(url: String, paymentId: UUID): ResponseEntity<String> =
+        coroutineScope {
+            val idempotencyKey = UUID.randomUUID().toString()
+            val result = CompletableDeferred<ResponseEntity<String>>()
+            val lastCall = AtomicLong(now() - 2 * delayTime)
+
+            val jobs = (0 until tries).map { attemptIndex ->
+                launch {
+                    try {
+                        requestSemaphore.withPermit {
+                            rateLimiter.tickSuspend()
+                            while (true) {
+                                val currentLastCall = lastCall.get()
+                                val delta = now() - currentLastCall
+                                if (delta > delayTime) {
+                                    if (lastCall.compareAndSet(currentLastCall, now())) {
+                                        break
+                                    }
+                                } else {
+                                    delay(delta)
+                                }
+                            }
+                            log(paymentId, "Starting call $attemptIndex")
+                            val response = webClient.post()
+                                .uri(url)
+                                .header("x-idempotency-key", idempotencyKey)
+                                .retrieve()
+                                .toEntity(String::class.java)
+                                .awaitSingle()
+
+                            if (response.statusCode.is2xxSuccessful) {
+                                if (result.complete(response)) {
+                                    log(paymentId, "Successful attempt: $attemptIndex")
+                                }
+                            }
+                        }
+                    } catch (_: CancellationException) {
+                    } catch (e: Exception) {
+                        log(paymentId, "Attempt $attemptIndex failed: ${e.message}")
+                    }
+                }
+            }
+
+            try {
+                withTimeout(requestAverageProcessingTime.toMillis() +
+                            delayTime * tries) {
+                    result.await()
+                }
+            } catch (e: TimeoutCancellationException) {
+                throw TimeoutException("Payment request timed out")
+            } finally {
+                jobs.forEach { it.cancel() }
+            }
+        }
+
+    private fun log(paymentId: UUID, msg: String) {
+        if (logConfig.enabled && paymentId.hashCode().absoluteValue % logConfig.sample == 0) {
+            logger.info("[$paymentId] $msg")
+        }
+    }
+}

--- a/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/PaymentExternalServiceImpl.kt
@@ -4,27 +4,21 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import kotlinx.coroutines.*
 import kotlinx.coroutines.reactor.awaitSingle
-import kotlinx.coroutines.reactor.awaitSingleOrNull
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpStatus
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
-import org.springframework.web.reactive.function.client.awaitBody
 import reactor.netty.http.client.HttpClient
 import reactor.netty.http.HttpProtocol
 import ru.quipy.common.utils.SlidingWindowRateLimiter
+import ru.quipy.config.*
 import java.io.IOException
 import java.net.ConnectException
 import java.time.Duration
 import java.util.concurrent.TimeoutException
-import ru.quipy.config.BackPressureConfig
-import ru.quipy.config.LogConfig
-import ru.quipy.config.RetriesConfig
-import ru.quipy.config.ThreadPoolsConfig
 import ru.quipy.core.EventSourcingService
 import ru.quipy.metrics.MetricsService
 import ru.quipy.payments.api.PaymentAggregate
@@ -34,7 +28,6 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.math.absoluteValue
-import kotlin.math.ceil
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
@@ -49,7 +42,9 @@ class PaymentExternalSystemAdapterImpl(
     private val metricsService: MetricsService,
     retriesConfig: RetriesConfig,
     private val logConfig: LogConfig,
-    private val backPressureConfig: BackPressureConfig
+    private val backPressureConfig: BackPressureConfig,
+    private val queueSimulationConfig: QueueSimulationConfig,
+    private val hedgedRequestsConfig: HedgedRequestsConfig,
 ) : PaymentExternalSystemAdapter {
 
     companion object {
@@ -86,6 +81,7 @@ class PaymentExternalSystemAdapterImpl(
     private val requestAverageProcessingTime = properties.averageProcessingTime
     private val rateLimitPerSec = properties.rateLimitPerSec
     private val parallelRequests = properties.parallelRequests
+    private val queueSimulationEnabled = queueSimulationConfig.enabled
 
     private val maxParallelRequestsCount =
         maxOf(parallelRequests, rateLimitPerSec * maxOf(1, requestAverageProcessingTime.toSeconds().toInt()))
@@ -95,10 +91,6 @@ class PaymentExternalSystemAdapterImpl(
         .protocol(HttpProtocol.H2C)
         .responseTimeout(Duration.ofMillis(maxOf(requestAverageProcessingTime.multipliedBy(2).toMillis(), 500)))
 
-    private val webClient = WebClient.builder()
-        .clientConnector(ReactorClientHttpConnector(httpClient))
-        .build()
-    private val rateLimiter = SlidingWindowRateLimiter(rateLimitPerSec.toLong(), 1.seconds.toJavaDuration())
     private val requestQueue: PaymentChannel = PaymentChannel(retriesConfig.payment.maxRetries)
 
     private val executorThreadNumber = threadPoolsConfig.paymentExternalServiceThreadPoolConfig.threadsNumber
@@ -112,7 +104,6 @@ class PaymentExternalSystemAdapterImpl(
     private val requestHandlerExecutorService = Executors.newFixedThreadPool(requestHandlerThreadNumber) as ThreadPoolExecutor
 
     private val maxConcurrentRequests: Int = parallelRequests
-    private val requestSemaphore = Semaphore(permits = maxConcurrentRequests)
 
     @Volatile
     private var lastRetryAfterTimestamp: Long? = null
@@ -124,6 +115,15 @@ class PaymentExternalSystemAdapterImpl(
 
     private val timeToProcessCounter =
         TimeToProcessCounter(requestAverageProcessingTime, maxConcurrentRequests, rateLimitPerSec)
+
+    private val parallelIdempotencyRequestsExecutorService =
+        ParallelIdempotencyRequestsExecutorService(
+            threadPoolsConfig = threadPoolsConfig,
+            tries = hedgedRequestsConfig.tries,
+            delayTime = hedgedRequestsConfig.delay,
+            properties = properties,
+            logConfig = logConfig,
+        )
 
     init {
         metricsService.registerQueueSizeGauge(accountName, this) { requestQueue.size().toDouble() }
@@ -157,7 +157,7 @@ class PaymentExternalSystemAdapterImpl(
 
             val timeNeededToProcessQueueWithNewRequest = timeToProcessCounter.computeTimeToProcessQueue(requestQueue.size() + 1).toMillis()
 
-            if (timeRemaining <= 0 || timeNeededToProcessQueueWithNewRequest + 100 > timeRemaining) {
+            if (timeRemaining <= 0 || (timeNeededToProcessQueueWithNewRequest + 100 > timeRemaining && queueSimulationEnabled)) {
                 lastRetryAfterTimestamp = currentTime + timeNeededToProcessQueueWithNewRequest
 
                 logger.warn("[$accountName] TooManyRequestsException for paymemt $paymentId, retry-after time $lastRetryAfterTimestamp ms, queue size ${requestQueue.size()}, time needed $timeNeededToProcessQueueWithNewRequest")
@@ -205,21 +205,19 @@ class PaymentExternalSystemAdapterImpl(
         while (true) {
             val request = requestQueue.take()
 
-            if (now() + requestAverageProcessingTime.toMillis() + 100 > request.deadline) {
+            if (now() + requestAverageProcessingTime.toMillis() + 100 > request.deadline && queueSimulationEnabled) {
                 continue
             }
 
-            requestSemaphore.withPermit {
-                processPaymentRequest(request)
-                // TODO: nice idea but token returns into new window and rate limit is breached for good requests
-                // val currentTime = now()
-                // if (currentTime + requestAverageProcessingTime.toMillis() > request.deadline) {
-                //     rateLimiter.returnToken()
-                //     logger.warn("[$accountName] Request ${request.paymentId} missed deadline, returning token to rate limiter")
-                // } else {
-                //     processPaymentRequest(request)
-                // }
-            }
+            processPaymentRequest(request)
+            // TODO: nice idea but token returns into new window and rate limit is breached for good requests
+            // val currentTime = now()
+            // if (currentTime + requestAverageProcessingTime.toMillis() > request.deadline) {
+            //     rateLimiter.returnToken()
+            //     logger.warn("[$accountName] Request ${request.paymentId} missed deadline, returning token to rate limiter")
+            // } else {
+            //     processPaymentRequest(request)
+            // }
 
             backgroundExecutorService.submit {
                 metricsService.incrementCompletedTask(TASK_NAME)
@@ -243,7 +241,6 @@ class PaymentExternalSystemAdapterImpl(
 
         val url = "http://$paymentProviderHostPort/external/process?serviceName=$serviceName&token=$token&accountName=$accountName&transactionId=${request.transactionId}&paymentId=${request.paymentId}&amount=${request.amount}"
 
-        rateLimiter.tickSuspend()
         val requestStartTime = now()
         try {
             val responseData: Pair<String, Int>? =
@@ -252,11 +249,7 @@ class PaymentExternalSystemAdapterImpl(
                         request.paymentId,
                         "[$accountName] Submit: ${request.paymentId} , txId: ${request.transactionId}, time spent ${now() - request.paymentStartedAt} ms"
                     )
-                    val response = webClient.post()
-                        .uri(url)
-                        .retrieve()
-                        .toEntity(String::class.java)
-                        .awaitSingle()
+                    val response = parallelIdempotencyRequestsExecutorService.executePaymentCall(url, request.paymentId)
 
                     Pair(response.body ?: "", response.statusCode.value())
                 } catch (e: Exception) {

--- a/src/main/kotlin/ru/quipy/payments/logic/TimeToProcessCounter.kt
+++ b/src/main/kotlin/ru/quipy/payments/logic/TimeToProcessCounter.kt
@@ -4,9 +4,9 @@ import org.slf4j.LoggerFactory
 import java.time.Duration
 
 class TimeToProcessCounter(
-    public val requestAverageProcessingTime: Duration,
-    public val maxConcurrentRequests: Int,
-    public val rateLimitPerSec: Int,
+    private val requestAverageProcessingTime: Duration,
+    private val maxConcurrentRequests: Int,
+    private val rateLimitPerSec: Int,
 ) {
     companion object {
         val logger = LoggerFactory.getLogger(TimeToProcessCounter::class.java)
@@ -51,7 +51,7 @@ class TimeToProcessCounter(
         logger.info("Precomputed processing times for requestAverageProcessingTime=$requestAverageProcessingTime, maxConcurrentRequests=$maxConcurrentRequests, rateLimitPerSec=$rateLimitPerSec, first values = [${observations[0]}, ${observations[1]}, ${observations[2]}, ${observations[3]}, ${observations[4]}]")
     }
 
-    public fun computeTimeToProcessQueue(queueSize: Int): Duration {
+    fun computeTimeToProcessQueue(queueSize: Int): Duration {
         val index = observations.binarySearch { it.requestsCount.compareTo(queueSize) }
         val sendTime = if (index >= 0) observations[index].time else observations[-index - 1].time
         return sendTime + requestAverageProcessingTime

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,6 +83,8 @@ thread-pools:
     threads-number: 128
     background-task-threads-number: 32
     request-handler-threads-number: 32
+  parallel-idempotency-requests-executor-service-thread-pool-config:
+    threads-number: 128
 
 retries:
   payment:
@@ -94,3 +96,10 @@ back-pressure:
 logging:
   enabled: true
   sample: 100
+
+queue-simulation:
+  enabled: false
+
+hedged-requests:
+  tries: 5
+  delay: 200


### PR DESCRIPTION
Кейс 11
Аккаунт: "acc-22"
```
{
  "ratePerSecond": 100,
  "testCount": 20000,
  "processingTimeMillis": 1500
}
```
# В чем была проблема?
Аккаунт имеет следующие параметры
```
accountName=acc-22, parallelRequests=20000, rateLimitPerSec=1100, price=5, averageProcessingTime=PT1.6S
```
Как можно заметить, среднее время выполнения запроса на аккаунте больше, чем время ожидания. Из-за этого ни один запрос не проходил, т.к. система считала, что она не успеет выполнить запрос
Посмотрим на график выполнения запроса на аккаунте
<img width="751" height="379" alt="image" src="https://github.com/user-attachments/assets/cfa554f3-3e06-4bac-b2a7-4f8417e99faa" />
По 0.5 перцентилю запросы выполняются за 0.67 секунд. 
# Решение
Воспользуемся техникой hedged requests. Будем посылать один и тот же запрос несколько раз через какое-то время. Экспериментальным путем подобрали значения 5 запросов, каждый отправляется раз в 200 мс
# Графики
## До
<img width="1582" height="619" alt="image" src="https://github.com/user-attachments/assets/ab4922b1-c5af-4e21-92fc-5b694aa401ff" />
## После
<img width="1546" height="692" alt="image" src="https://github.com/user-attachments/assets/71eb8bde-b5c8-455b-bb8b-2009c2d5c455" />
Можно заметить постоянный фон ошибок на протяжении всего теста, примерно 4%. Всего можем отправить 4 запроса с одним ключом идемпотентности. 1-0.5^4=0.9375. Значение успешных запросов выше из-за того что отправляется еще и 5 запрос, который не всегда при этом успевает обработаться и его нельзя учитывать при подсчете вероятности, т.к. оставшееся время на исполнение меньше 0.5 перцентиля